### PR TITLE
Add Star Track flag

### DIFF
--- a/src/Auspost.php
+++ b/src/Auspost.php
@@ -16,6 +16,7 @@ class Auspost {
 	private $api_password   = null;
 	private $account_number = null;
 	private $test_mode      = null;
+	private $star_track     = null;
 
 	const API_SCHEME = 'tls://';
 	const API_HOST   = 'digitalapi.auspost.com.au';
@@ -31,10 +32,11 @@ class Auspost {
 	 * @param string $account_number The AusPost Account number
 	 * @param bool $test_mode Whether to use test mode or not
 	 */
-	public function __construct($api_key, $api_password, $account_number, $test_mode = false) {
+	public function __construct($api_key, $api_password, $account_number, $star_track = false, $test_mode = false) {
 		$this->api_key = $api_key;
 		$this->api_password = $api_password;
-		$this->account_number = str_pad($account_number, 10, '0', STR_PAD_LEFT); // Ensure the account number is zero padded 10 digits
+		$this->star_track = $star_track;
+		$this->account_number = !$star_track ? str_pad($account_number, 10, '0', STR_PAD_LEFT) : $account_number; // Ensure the account number is zero padded 10 digits
 		$this->test_mode = $test_mode;
 	}
 

--- a/src/Auspost.php
+++ b/src/Auspost.php
@@ -32,12 +32,23 @@ class Auspost {
 	 * @param string $account_number The AusPost Account number
 	 * @param bool $test_mode Whether to use test mode or not
 	 */
-	public function __construct($api_key, $api_password, $account_number, $star_track = false, $test_mode = false) {
+	public function __construct($api_key, $api_password, $account_number, $test_mode = false) {
 		$this->api_key = $api_key;
 		$this->api_password = $api_password;
-		$this->star_track = $star_track;
-		$this->account_number = !$star_track ? str_pad($account_number, 10, '0', STR_PAD_LEFT) : $account_number; // Ensure the account number is zero padded 10 digits
+		$this->account_number = str_pad($account_number, 10, '0', STR_PAD_LEFT); // Ensure the account number is zero padded 10 digits
 		$this->test_mode = $test_mode;
+	}
+	
+	/**
+	 * Flags the Auspost instance as StarTrack
+	 *
+	 * @param string $account_number The StarTrack Account number
+	 * @return void
+	 */
+	public function starTrack($account_number)
+	{
+		$this->star_track = true;
+		$this->account_number = $account_number;
 	}
 
 	/**

--- a/src/Auspost.php
+++ b/src/Auspost.php
@@ -31,10 +31,10 @@ class Auspost {
 	 * @param string $account_number The AusPost Account number
 	 * @param bool $test_mode Whether to use test mode or not
 	 */
-	public function __construct($api_key, $api_password, $account_number, $test_mode = false) {
+	public function __construct($api_key, $api_password, $account_number, $star_track = false, $test_mode = false) {
 		$this->api_key = $api_key;
 		$this->api_password = $api_password;
-		$this->account_number = str_pad($account_number, 10, '0', STR_PAD_LEFT); // Ensure the account number is zero padded 10 digits
+		$this->account_number = !$star_track ? str_pad($account_number, 10, '0', STR_PAD_LEFT) : $account_number; // Ensure the account number is zero padded 10 digits
 		$this->test_mode = $test_mode;
 	}
 

--- a/src/Shipment.php
+++ b/src/Shipment.php
@@ -84,10 +84,12 @@ class Shipment {
     public function getQuotes() {
         $request = [
             'from' => [
+	              'suburb' => $this->from->suburb,
                 'postcode' => $this->from->postcode,
                 'country' => $this->from->country,
             ],
             'to' => [
+	              'suburb' => $this->to->suburb,
                 'postcode' => $this->to->postcode,
                 'country' => $this->to->country,
             ],


### PR DESCRIPTION
Hi Josh,

Thanks for creating this library. I am trying to integrate StarTrack API into my project. 

I did some testing and it seems that the API does not like digit account number sent in the header if the account is a StarTrack account.

I tried editing your code to remove the padding and that solved the issue.

I have added a StarTrack flag when creating a `new Auspost` instance. Please check it out and merge the request.

Regards